### PR TITLE
fix: resolve Moonraker startup warnings

### DIFF
--- a/config/moonraker.conf
+++ b/config/moonraker.conf
@@ -1,5 +1,4 @@
 [secrets]
-secrets_path: ~/printer_data/config/moonraker.secrets
 
 [server]
 host: 0.0.0.0
@@ -39,7 +38,6 @@ address: 192.168.1.222
 port: 8123
 device: switch.plug_2
 token: {secrets.homeassistant.token}
-domain: switch
 
 #[timelapse]
 ##   Following basic configuration is default to most images and don't need

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,7 +85,12 @@ services:
       - /run/dbus:/run/dbus
       # Moonraker configuration
       - ./config:/opt/printer_data/config
-      - ./config/moonraker.secrets:/opt/printer_data/moonraker.secrets:ro
+      - type: bind
+        source: ./config/moonraker.secrets
+        target: /opt/printer_data/moonraker.secrets
+        read_only: true
+        bind:
+          create_host_path: false
       - ./moonraker/database:/opt/printer_data/database
       - ./moonraker/logs:/opt/printer_data/logs
       - ./gcodes:/opt/printer_data/gcodes

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,6 +85,7 @@ services:
       - /run/dbus:/run/dbus
       # Moonraker configuration
       - ./config:/opt/printer_data/config
+      - ./config/moonraker.secrets:/opt/printer_data/moonraker.secrets:ro
       - ./moonraker/database:/opt/printer_data/database
       - ./moonraker/logs:/opt/printer_data/logs
       - ./gcodes:/opt/printer_data/gcodes


### PR DESCRIPTION
## Changes

### `config/moonraker.conf`
- **Remove deprecated `secrets_path`** from `[secrets]` — Moonraker auto-discovers `moonraker.secrets` from the data path (`/opt/printer_data/moonraker.secrets`). The old `~/printer_data/...` path was resolving to `/root/` inside the container, causing the "file does not exist" warning.
- **Remove `domain: switch`** from `[power printer]` — this option no longer exists in the HA power device type. Its removal fixes the `Unparsed config option` warning and the Jinja2 template error that prevented the power device from loading.

### `docker-compose.yaml`
- **Mount `moonraker.secrets` at `/opt/printer_data/moonraker.secrets`** — makes the secrets file available at the path Moonraker expects when launched with `-d /opt/printer_data`, so `{secrets.homeassistant.token}` resolves correctly.

## Warnings fixed
- `[secrets]: Option 'secrets_path' is deprecated`
- `[secrets]: file does not exist: '/root/printer_data/config/moonraker.secrets'`
- `Failed to load power device [power printer] / Error rendering Jinja2 Template`
- `Unparsed config option 'domain: switch' detected in section [power printer]`